### PR TITLE
#4 Validation errors improvements

### DIFF
--- a/services/authentication-service/docs/openapi.yml
+++ b/services/authentication-service/docs/openapi.yml
@@ -29,29 +29,55 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegisterCustomerResponse'
         '400':
-          description: Invalid input
+          description: Invalid input or validation error
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum:
-                      - Invalid email
-                      - Invalid password
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRequest:
+                  summary: Invalid JSON
+                  value:
+                    code: INVALID_REQUEST
+                    message: invalid request
+                    details: [ ]
+                validationError:
+                  summary: Validation error
+                  value:
+                    code: VALIDATION_ERROR
+                    message: validation failed
+                    details:
+                      - email is required
+                      - password is required
+                      - name is required
+                      - email must be a valid email address
+                      - password must be a valid password with at least 8 characters long
         '409':
           description: Customer already exists
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    enum:
-                      - Customer already exists
-
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                customerExists:
+                  summary: Customer already exists
+                  value:
+                    code: CUSTOMER_ALREADY_EXISTS
+                    message: customer already exists
+                    details: [ ]
+        '500':
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                customerExists:
+                  summary: Unexpected error
+                  value:
+                    code: INTERNAL_ERROR
+                    message: failed to register the customer
+                    details: [ ]
 components:
   schemas:
     RegisterCustomerRequest:
@@ -80,8 +106,8 @@ components:
       properties:
         id:
           type: string
-          pattern: '^[a-fA-F0-9]{24}$'
-          example: 507f1f77bcf86cd799439011
+          pattern: '^[a-zA-Z0-9\-]+$'
+          example: fake-id
         email:
           type: string
           format: email
@@ -93,4 +119,21 @@ components:
         created_at:
           type: string
           format: date-time
-          example: 2024-06-01T12:00:00Z
+          example: 2025-01-01T00:00:00Z
+
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          example: VALIDATION_ERROR
+        message:
+          type: string
+          example: validation failed
+        details:
+          type: array
+          items:
+            type: string
+          example:
+            - email is required
+            - password is required


### PR DESCRIPTION
How error response was implemented was exposing implementation details of the service, at the same time the format wasn't good. With this new format we don't expose details of the service, which means that we can migrate that validator or event the tech stack to another one without breaking the api. At the same time, it becomes easier to read and understand 